### PR TITLE
Support for documenting only endpoints with specified tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ const start = async () => {
     docsPath: '/docs',
     jsonPath: '/openapi.json',
     enableSwaggerUI: true,
+    includedTags: ['public'],
   }));
   await server.start();
   console.log(`Server running on ${server.info.uri}`);
@@ -183,6 +184,7 @@ The `swaggerPlugin` supports the following options:
 - **jsonPath**: The path to access the OpenAPI JSON schema. Default: `'/ops/openapi.json'`.
 - **enableSwaggerUI**: Whether to enable the Swagger UI. Default: `true`.
 - **defaultResponseSchema**: The default response schema for all routes. Default: `z.object({ success: z.boolean() })`.
+- **includedTags**: Limit documentation to only routes tagged with one of the `includedTags`. Default: `[]` (document every route).
 
 ## Collaborators
 

--- a/src/swaggerplugin.ts
+++ b/src/swaggerplugin.ts
@@ -9,6 +9,7 @@ export interface ZodDocsOptions {
   jsonPath?: string;
   enableSwaggerUI?: boolean;
   defaultResponseSchema?: z.ZodTypeAny;
+  includedTags?: string[];
 }
 
 /**
@@ -38,6 +39,12 @@ export const swaggerPlugin = (options: ZodDocsOptions = {}): Plugin<{}> => {
     version: '1.0.0',
     register: async (server) => {
       const paths: OpenAPIObject['paths'] = {};
+
+      let routes = server.table();
+      if (includedTags.length) {
+        // Only document routes tagged with one of includedTags[]
+        routes = routes.filter(route => route.settings.tags?.some(tag => includedTags.includes(tag)))
+      }
 
       for (const route of server.table()) {
         const zodConfig = route.settings?.plugins?.zod;


### PR DESCRIPTION
Sometimes you don't want to include every route in the documentation. 

Hapi uses route tags for this purpose (see e.g. [hapi-swagger](https://github.com/hapi-swagger/hapi-swagger?tab=readme-ov-file#tagging-your-api-routes)). 

This PR adds support for limiting the documentation to only routes with specified tags.